### PR TITLE
Support building on Node 6

### DIFF
--- a/ced.cpp
+++ b/ced.cpp
@@ -1,5 +1,5 @@
 #define NAPI_VERSION 2
-#include <node_api.h>
+#include <node/node_api.h>
 
 #include <compact_enc_det/compact_enc_det.h>
 


### PR DESCRIPTION
Node 6 requires `node_api.h` to be pulled in via `node/node_api.h`. Changing to this method does not break compatibility with later versions of node, so it looks like it's safe to change. (I've used the library via Node 6 and Node 10 with this change.)